### PR TITLE
plugs leaky abstraction

### DIFF
--- a/datatypes/src/main/java/org/hyperledger/besu/datatypes/SetCodeAuthorization.java
+++ b/datatypes/src/main/java/org/hyperledger/besu/datatypes/SetCodeAuthorization.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.datatypes;
 import org.hyperledger.besu.crypto.SECPSignature;
 
 import java.math.BigInteger;
-import java.util.List;
 import java.util.Optional;
 
 /**
@@ -59,13 +58,6 @@ public interface SetCodeAuthorization {
    * @return all the optional nonce
    */
   Optional<Long> nonce();
-
-  /**
-   * Return all nonces in the list
-   *
-   * @return all the nonces
-   */
-  List<Long> nonceList();
 
   /**
    * Return the recovery id.

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/encoding/SetCodeTransactionEncoder.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/encoding/SetCodeTransactionEncoder.java
@@ -60,7 +60,7 @@ public class SetCodeTransactionEncoder {
     rlpOutput.writeBigIntegerScalar(payload.chainId());
     rlpOutput.writeBytes(payload.address().copy());
     rlpOutput.startList();
-    payload.nonceList().forEach(rlpOutput::writeLongScalar);
+    payload.nonce().ifPresent(rlpOutput::writeLongScalar);
     rlpOutput.endList();
   }
 

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/encoding/SetCodeTransactionDecoderTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/encoding/SetCodeTransactionDecoderTest.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.ethereum.core.encoding;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.hyperledger.besu.crypto.SECPSignature;
 import org.hyperledger.besu.datatypes.Address;
@@ -42,7 +43,6 @@ class SetCodeTransactionDecoderTest {
     assertThat(authorization.chainId()).isEqualTo(BigInteger.ONE);
     assertThat(authorization.address())
         .isEqualTo(Address.fromHexStringStrict("0x633688abc3cCf8B0C03088D2d1C6ae4958c2fA56"));
-    assertThat(authorization.nonceList().size()).isEqualTo(1);
     assertThat(authorization.nonce().get()).isEqualTo(0L);
 
     final SECPSignature signature = authorization.signature();
@@ -67,7 +67,7 @@ class SetCodeTransactionDecoderTest {
     assertThat(authorization.chainId()).isEqualTo(BigInteger.ONE);
     assertThat(authorization.address())
         .isEqualTo(Address.fromHexStringStrict("0x633688abc3cCf8B0C03088D2d1C6ae4958c2fA56"));
-    assertThat(authorization.nonceList().size()).isEqualTo(0);
+    assertThat(authorization.nonce()).isEmpty();
 
     final SECPSignature signature = authorization.signature();
     assertThat(signature.getRecId()).isEqualTo((byte) 1);
@@ -78,7 +78,7 @@ class SetCodeTransactionDecoderTest {
   }
 
   @Test
-  void shouldDecodeInnerPayloadWithMultipleNonces() {
+  void shouldThrowInnerPayloadWithMultipleNonces() {
     // "d90194633688abc3ccf8b0c03088d2d1c6ae4958c2fa56c20107"
 
     final BytesValueRLPInput input =
@@ -86,21 +86,12 @@ class SetCodeTransactionDecoderTest {
             Bytes.fromHexString(
                 "0xf85c0194633688abc3ccf8b0c03088d2d1c6ae4958c2fa56c2010201a0401b5d4ebe88306448115d1a46a30e5ad1136f2818b4ebb0733d9c4efffd135aa0753ff1dbce6db504ecb9635a64d8c4506ff887e2d2a0d2b7175baf94c849eccc"),
             true);
-    final SetCodeAuthorization authorization = SetCodeTransactionDecoder.decodeInnerPayload(input);
 
-    assertThat(authorization.chainId()).isEqualTo(BigInteger.ONE);
-    assertThat(authorization.address())
-        .isEqualTo(Address.fromHexStringStrict("0x633688abc3cCf8B0C03088D2d1C6ae4958c2fA56"));
-    assertThat(authorization.nonceList().size()).isEqualTo(2);
-    assertThat(authorization.nonce().get()).isEqualTo(1L);
-    assertThat(authorization.nonceList().get(1)).isEqualTo(2L);
-
-    final SECPSignature signature = authorization.signature();
-    assertThat(signature.getRecId()).isEqualTo((byte) 1);
-    assertThat(signature.getR().toString(16))
-        .isEqualTo("401b5d4ebe88306448115d1a46a30e5ad1136f2818b4ebb0733d9c4efffd135a");
-    assertThat(signature.getS().toString(16))
-        .isEqualTo("753ff1dbce6db504ecb9635a64d8c4506ff887e2d2a0d2b7175baf94c849eccc");
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          SetCodeTransactionDecoder.decodeInnerPayload(input);
+        });
   }
 
   @Test

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/encoding/SetCodeTransactionEncoderTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/encoding/SetCodeTransactionEncoderTest.java
@@ -23,8 +23,7 @@ import org.hyperledger.besu.ethereum.core.SetCodeAuthorization;
 import org.hyperledger.besu.ethereum.rlp.BytesValueRLPOutput;
 
 import java.math.BigInteger;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 import com.google.common.base.Suppliers;
@@ -51,7 +50,7 @@ class SetCodeTransactionEncoderTest {
         new SetCodeAuthorization(
             BigInteger.ONE,
             Address.fromHexString("0x633688abc3cCf8B0C03088D2d1C6ae4958c2fA56"),
-            List.of(0L),
+            Optional.of(0L),
             SIGNATURE_ALGORITHM
                 .get()
                 .createSignature(
@@ -77,7 +76,7 @@ class SetCodeTransactionEncoderTest {
         new SetCodeAuthorization(
             BigInteger.ONE,
             Address.fromHexString("0x633688abc3cCf8B0C03088D2d1C6ae4958c2fA56"),
-            new ArrayList<>(),
+            Optional.empty(),
             SIGNATURE_ALGORITHM
                 .get()
                 .createSignature(
@@ -96,32 +95,6 @@ class SetCodeTransactionEncoderTest {
   }
 
   @Test
-  void shouldEncodeSingleSetCodeWithMultipleNonces() {
-    // "d90194633688abc3ccf8b0c03088d2d1c6ae4958c2fa56c20107"
-
-    final SetCodeAuthorization authorization =
-        new SetCodeAuthorization(
-            BigInteger.ONE,
-            Address.fromHexString("0x633688abc3cCf8B0C03088D2d1C6ae4958c2fA56"),
-            List.of(1L, 2L),
-            SIGNATURE_ALGORITHM
-                .get()
-                .createSignature(
-                    new BigInteger(
-                        "401b5d4ebe88306448115d1a46a30e5ad1136f2818b4ebb0733d9c4efffd135a", 16),
-                    new BigInteger(
-                        "753ff1dbce6db504ecb9635a64d8c4506ff887e2d2a0d2b7175baf94c849eccc", 16),
-                    (byte) 1));
-
-    SetCodeTransactionEncoder.encodeSingleSetCode(authorization, output);
-
-    assertThat(output.encoded())
-        .isEqualTo(
-            Bytes.fromHexString(
-                "0xf85c0194633688abc3ccf8b0c03088d2d1c6ae4958c2fa56c2010201a0401b5d4ebe88306448115d1a46a30e5ad1136f2818b4ebb0733d9c4efffd135aa0753ff1dbce6db504ecb9635a64d8c4506ff887e2d2a0d2b7175baf94c849eccc"));
-  }
-
-  @Test
   void shouldEncodeSingleSetCodeWithoutNonceAndChainIdZero() {
     // "d70094633688abc3ccf8b0c03088d2d1c6ae4958c2fa56c5"
 
@@ -129,7 +102,7 @@ class SetCodeTransactionEncoderTest {
         new SetCodeAuthorization(
             BigInteger.ZERO,
             Address.fromHexString("0x633688abc3cCf8B0C03088D2d1C6ae4958c2fA56"),
-            new ArrayList<>(),
+            Optional.empty(),
             SIGNATURE_ALGORITHM
                 .get()
                 .createSignature(


### PR DESCRIPTION
Keeps any other code from needing to know our dirty little secret on how Optionals are represented in RLP

